### PR TITLE
Fix a word in installation (instal => install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Gulp.js plugin to visualize task dependency graph within your gulpfile.
 ## Installation
 
 ```
-npm instal --save-dev gulp-task-graph-visualizer
+npm install --save-dev gulp-task-graph-visualizer
 ```
 
 ## Usage


### PR DESCRIPTION
The installation command is `npm instal --save-dev gulp-task-graph-visualizer`.
It should be `npm install --save-dev gulp-task-graph-visualizer`